### PR TITLE
markdownに対応

### DIFF
--- a/chatapp/package.json
+++ b/chatapp/package.json
@@ -7,10 +7,11 @@
     "start": "vite"
   },
   "dependencies": {
+    "marked": "^15.0.12",
     "socket.io": "^4.5.3",
     "socket.io-client": "^4.5.3",
-    "vue-router": "^4.1.6",
     "vue": "^3.2.45",
+    "vue-router": "^4.1.6",
     "vuetify": "^3.1.1"
   },
   "devDependencies": {

--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -3,9 +3,6 @@
   import socketManager from '../socketManager.js'
   import { marked } from "marked"
 
-// markedの改行オプションをtrueに設定
-marked.setOptions({breaks : true});
-
   // markedの改行オプションをtrueに設定
   marked.setOptions({breaks : true});
 
@@ -51,7 +48,6 @@ marked.setOptions({breaks : true});
     }
     // 入力欄を初期化
     chatContent.value = ""
-
   }
 
   // 退室メッセージをサーバに送信する

--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -3,9 +3,11 @@
   import socketManager from '../socketManager.js'
   import { marked } from "marked"
 
+  // markedの改行オプションをtrueに設定
+  marked.setOptions({breaks : true});
+
   // #region global state
   const userName = inject("userName")
-  // #endregion
 
   // #region local variable
   const socket = socketManager.getInstance()

--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -1,6 +1,7 @@
 <script setup>
-  import { inject, ref, reactive, onMounted, useTemplateRef } from "vue"
+  import { inject, ref, reactive, onMounted, useTemplateRef, computed} from "vue" // coputed追加
   import socketManager from '../socketManager.js'
+  import { marked } from "marked"
 
   // #region global state
   const userName = inject("userName")
@@ -14,6 +15,10 @@
   const chatContent = ref("")
   const chatList = reactive([])
   // #endregion
+
+  const markdown = computed(() => {
+    return marked.parse(chatContent.value)
+  });
 
   // #region lifecycle
   onMounted(() => {
@@ -49,6 +54,7 @@
     socket.emit("exitEvent", {
       type: "exit",
       name: userName.value,
+      content: markdown.value, // chatContentからmarkdownに変更
       datetime: Date.now()
     })
   }
@@ -138,7 +144,8 @@
               {{ chat.name }}が退室しました。
             </span>
             <span v-if="chat.type === 'publish'">
-              {{ chat.name }}：{{ chat.content }}
+              {{ chat.name }}：
+              <span v-html="chat.content"></span>
             </span>
             <span v-if="chat.type === 'memo'">
               {{ chat.name }}のメモ：{{ chat.content }}

--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -42,7 +42,7 @@
       socket.emit("publishEvent", {
         type: "publish",
         name: userName.value,
-        content: chatContent.value,
+        content: markdown.value,
         datetime: Date.now()
       })
     }
@@ -55,7 +55,6 @@
     socket.emit("exitEvent", {
       type: "exit",
       name: userName.value,
-      content: markdown.value, // chatContentからmarkdownに変更
       datetime: Date.now()
     })
   }

--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -181,7 +181,8 @@
               {{ chat.name }}が退室しました。
             </span>
             <span v-if="chat.type === 'publish'">
-              {{ chat.name }}：{{ chat.content }}
+              {{ chat.name }}：
+              <span v-html="chat.content"></span>
             </span>
             <span v-if="chat.type === 'memo'">
               {{ chat.name }}のメモ：{{ chat.content }}


### PR DESCRIPTION
textareaにマークダウンが入力された際に、適切に表示できるようにChat.vueを変更
(変更点)
・computedをインポート
・markedをインポート(npm install markedでインストール必要)
・サーバに送信するメッセージオブジェクトのcontent属性をhtml要素に変換した文字列に変更。
・表示する際にはv-htmlでchat.contentを表示するよう変更。